### PR TITLE
ci: publish to self-hosted registry (registry.mormor.cloud)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,12 +12,12 @@ on:
         type: string
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: registry.mormor.cloud   # self-hosted Zot (WG-only → must run on self-hosted)
+  IMAGE_NAME: ytclipper-go
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, homelab-vps]
     permissions:
       contents: read
       packages: write
@@ -30,8 +30,8 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        username: ci
+        password: ${{ secrets.REGISTRY_PASSWORD }}
 
     - name: Extract metadata
       id: meta


### PR DESCRIPTION
Switches image publishing from GHCR to the self-hosted **Zot** registry.

- `REGISTRY` → `registry.mormor.cloud`, `IMAGE_NAME` → `ytclipper-go`.
- **`runs-on` → self-hosted** (the registry is WG-only; GitHub-hosted can't reach it). Uses the existing `vps-ytclipper` runner.
- Login as `ci` via a new **`REGISTRY_PASSWORD`** repo secret.

**Before merging:** `gh secret set REGISTRY_PASSWORD -R MorrisMorrison/ytclipper-go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)