### PR TITLE
fix: revert to GHCR + GitHub-hosted (public repo, no self-hosted)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,12 +12,12 @@ on:
         type: string
 
 env:
-  REGISTRY: registry.mormor.cloud   # self-hosted Zot (WG-only → must run on self-hosted)
-  IMAGE_NAME: ytclipper-go
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
-    runs-on: [self-hosted, linux, x64, homelab-vps]
+    runs-on: ubuntu-latest   # PUBLIC repo → GitHub-hosted only (never self-hosted)
     permissions:
       contents: read
       packages: write
@@ -30,8 +30,8 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
-        username: ci
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Extract metadata
       id: meta


### PR DESCRIPTION
Reverts #12. ytclipper-go is a **public** repo, so it must not use a self-hosted runner (fork PRs could run code on the host) or the WG-only registry. Back to `ghcr.io` + `ubuntu-latest`.

Pairs with: removing `runner-ytclipper` from the homelab github-runner stack. The self-hosted registry stays for the **private** repos (schist, crypto-trading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)