### PR TITLE
Add deno JS runtime to Docker image for yt-dlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,19 @@ WORKDIR /app
 
 # Update and install system dependencies
 RUN apt-get update && \
-    apt-get install -y make python3 python3-pip python3-requests python3-urllib3 curl ffmpeg && \
+    apt-get install -y make python3 python3-pip python3-requests python3-urllib3 curl unzip ffmpeg && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install yt-dlp separately, as it may not have a Debian package
 RUN python3 -m pip install --no-warn-script-location --upgrade yt-dlp --break-system-packages
+
+# Install deno as a JavaScript runtime for yt-dlp.
+# yt-dlp shells out to `deno` to solve YouTube's JS challenges; without a JS
+# runtime on PATH, YouTube extraction is deprecated and some formats go missing.
+# DENO_INSTALL=/usr/local lands the binary at /usr/local/bin/deno (already on PATH).
+# Pinned to a specific version for reproducible builds.
+RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh -s v2.8.3 && \
+    deno --version
 
 # Create videos directory
 RUN mkdir -p /app/videos && chmod 777 /app/videos


### PR DESCRIPTION
## What

Installs **deno** (pinned to `v2.8.3`) into the Docker image so yt-dlp has a JavaScript runtime available at request time.

## Why

yt-dlp recently started emitting:

> No supported JavaScript runtime could be found. Only deno is enabled by default… YouTube extraction without a JS runtime has been deprecated, and some formats may be missing.

yt-dlp shells out to `deno` to solve YouTube's JS challenges. With no JS runtime on `PATH`, YouTube extraction is deprecated and some formats are dropped. Installing deno removes the deprecation warning and restores full format coverage.

## Changes (`Dockerfile` only)

- Install deno via the official `install.sh` with `DENO_INSTALL=/usr/local`, landing the binary at `/usr/local/bin/deno` (already on `PATH` for the running app).
- **Version pinned** to `v2.8.3` for reproducible builds (matches the project's dependency-pinning convention) rather than installing "latest".
- Added `unzip` to the apt-get step — deno's install script needs it to unpack the release archive, and it is not present in the `golang:1.23` base image.
- `RUN deno --version` after install so a broken install fails the build early.

No base-image change, no restructuring.

## Verification

Docker was not available on the machine where this change was made, so the image **could not be built locally**. CI must build the image to verify — the `deno --version` line will fail the build if the install is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)